### PR TITLE
Get params are not url encoded when relayed #102

### DIFF
--- a/src/main/resources/lib/nextjs-proxy/event.es6
+++ b/src/main/resources/lib/nextjs-proxy/event.es6
@@ -41,6 +41,6 @@ function postRevalidateRequest(path) {
         followRedirects: false,
     });
     if (response.status !== 200) {
-        log.warn(`Revalidate request for path '${path}' status: ${response.status}`);
+        log.warning(`Revalidate request for path '${path}' status: ${response.status}`);
     }
 }

--- a/src/main/resources/lib/nextjs-proxy/parsing.es6
+++ b/src/main/resources/lib/nextjs-proxy/parsing.es6
@@ -147,7 +147,7 @@ export const relayUriParams = (req, frontendRequestPath, nextjsCookies, componen
     const keys = Object.keys(params);
     if (keys.length > 0) {
         const paramsString = keys
-            .map(key => `${key}=${params[key]}`)
+            .map(key => `${key}=${encodeURIComponent(params[key])}`)
             .join('&');
 
         reqPath += '?' + paramsString;


### PR DESCRIPTION
Required for https://github.com/enonic/nextjs-enonic-demo/issues/376